### PR TITLE
feat: output target es2015

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "ESNext",
+    "target": "ES2015",
     "jsx": "react",
     "module": "es2015",
     "downlevelIteration": true,


### PR DESCRIPTION
Changing the output target to es2015 as esnext is not compatible, and causes issues with some bundlers and compilers.