### PR TITLE
fix: ShellTriggerButton icon disappears when used with CSS reset / tailwindcss

### DIFF
--- a/src/DevTools/Extension/Extension.tsx
+++ b/src/DevTools/Extension/Extension.tsx
@@ -12,7 +12,8 @@ const shellTriggerButtonStyles: Sx = () => ({
   left: 10,
   bottom: 10,
   borderRadius: '50%',
-  padding: '2rem',
+  width: '4rem',
+  height: '4rem',
   zIndex: 99999,
   img: {
     height: '2rem',


### PR DESCRIPTION
see #34 