### PR TITLE
chore: add husky prepare script to install automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "release:minor": "yarn run release minor",
     "release:patch": "yarn run release patch",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Chunk of this PR: https://github.com/jotaijs/jotai-devtools/pull/32

The prepare script will install git hooks (for commitlint) automatically when running `yarn install` for new contributors.