### PR TITLE
refactor(utils): extract useReduxConnection for less repetition

### DIFF
--- a/src/utils/redux-extension/createReduxConnection.ts
+++ b/src/utils/redux-extension/createReduxConnection.ts
@@ -5,9 +5,6 @@ import { ReduxExtension } from './getReduxExtension';
 type ConnectResponse = ReturnType<NonNullable<ReduxExtension>['connect']>;
 
 export type Connection = {
-  /** Mark the connection as not initiated, so it can be initiated before using it. */
-  shouldInit?: boolean;
-
   /** Initiate the connection and add it to the extension connections.
    *  Should only be executed once in the live time of the connection.
    */
@@ -40,7 +37,5 @@ export const createReduxConnection = (
   if (!extension) return undefined;
   const connection = extension.connect({ name });
 
-  return Object.assign(connection, {
-    shouldInit: true,
-  }) as Connection;
+  return connection as Connection;
 };

--- a/src/utils/redux-extension/useReduxConnection.ts
+++ b/src/utils/redux-extension/useReduxConnection.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react';
+import { Connection, createReduxConnection } from './createReduxConnection';
+import { getReduxExtension } from './getReduxExtension';
+
+interface ConnectionConfig<T> {
+  name: string;
+  enabled: boolean | undefined;
+  initialValue: T;
+  disconnectAllOnCleanup?: boolean;
+}
+
+export const useReduxConnection = <T>({
+  name,
+  initialValue,
+  enabled,
+  disconnectAllOnCleanup,
+}: ConnectionConfig<T>) => {
+  const connectionRef = useRef<Connection>();
+  const firstValue = useRef(initialValue);
+
+  useEffect(() => {
+    const extension = getReduxExtension(enabled);
+
+    const connection = createReduxConnection(extension, name);
+    connection?.init(firstValue.current);
+    connectionRef.current = connection;
+
+    return () => {
+      if (disconnectAllOnCleanup) extension?.disconnect?.();
+    };
+  }, [name, enabled, disconnectAllOnCleanup]);
+
+  return connectionRef;
+};

--- a/src/utils/useDidMount.ts
+++ b/src/utils/useDidMount.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from 'react';
+
+export const useDidMount = () => {
+  const didMount = useRef(false);
+  useEffect(() => {
+    didMount.current = true;
+  }, []);
+  return didMount.current;
+};


### PR DESCRIPTION
Chunk of this PR: https://github.com/jotaijs/jotai-devtools/pull/32

This will extract the repeated logic of `useAtomDevtools` and `useAtomsDevtools` regarding the initial connection to the redux extension into a shared custom hook. It will be helpful to implement consistent behavior for both hooks. 🙂

(for example when https://github.com/reduxjs/redux-devtools/issues/1370 is fixed or #32 is implemented as temporary solution or if there is any other solution for the duplicated connection problem)

This is only a refactoring, it should not introduce any behavioral changes.
