### PR TITLE
fix: add backward compatible store support for <=2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "jest-watch-typeahead": "^2.2.2",
-    "jotai": "^2.0.4",
+    "jotai": "^2.1.0",
     "jotai-tanstack-query": "^0.7.0",
     "lint-staged": "^13.2.2",
     "prettier": "^2.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,7 +128,7 @@ devDependencies:
     version: 5.59.1(eslint@8.39.0)(typescript@5.0.4)
   babel-loader:
     specifier: ^9.1.2
-    version: 9.1.2(@babel/core@7.21.5)(webpack@5.81.0)
+    version: 9.1.2(@babel/core@7.21.5)(webpack@5.82.0)
   base16:
     specifier: ^1.0.0
     version: 1.0.0
@@ -181,11 +181,11 @@ devDependencies:
     specifier: ^2.2.2
     version: 2.2.2(jest@29.5.0)
   jotai:
-    specifier: ^2.0.4
-    version: 2.0.4(react@18.2.0)
+    specifier: ^2.1.0
+    version: 2.1.0(react@18.2.0)
   jotai-tanstack-query:
     specifier: ^0.7.0
-    version: 0.7.0(@tanstack/query-core@4.29.5)(jotai@2.0.4)
+    version: 0.7.0(@tanstack/query-core@4.29.5)(jotai@2.1.0)
   lint-staged:
     specifier: ^13.2.2
     version: 13.2.2
@@ -5282,6 +5282,19 @@ packages:
       webpack: 5.81.0(@swc/core@1.3.55)(esbuild@0.17.18)
     dev: true
 
+  /babel-loader@9.1.2(@babel/core@7.21.5)(webpack@5.82.0):
+    resolution: {integrity: sha512-mN14niXW43tddohGl8HPu5yfQq70iUThvFL/4QzESA7GcZoC0eVOhvWdQ8+3UlSjaDE9MVtsW9mxDY07W7VpVA==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      '@babel/core': ^7.12.0
+      webpack: '>=5'
+    dependencies:
+      '@babel/core': 7.21.5
+      find-cache-dir: 3.3.2
+      schema-utils: 4.0.1
+      webpack: 5.82.0(@swc/core@1.3.55)(esbuild@0.17.18)
+    dev: true
+
   /babel-plugin-add-react-displayname@0.0.5:
     resolution: {integrity: sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==}
     dev: true
@@ -9531,18 +9544,18 @@ packages:
       - ts-node
     dev: true
 
-  /jotai-tanstack-query@0.7.0(@tanstack/query-core@4.29.5)(jotai@2.0.4):
+  /jotai-tanstack-query@0.7.0(@tanstack/query-core@4.29.5)(jotai@2.1.0):
     resolution: {integrity: sha512-/fzDgMDmJYHYCHHCfWtcHJCiNkxiLJazIza4FEyXptGIDIEVDHvmt8TWmHBbbqgXLkQOjJEWb2HwUIwmATyAew==}
     peerDependencies:
       '@tanstack/query-core': '*'
       jotai: '>=1.11.0'
     dependencies:
       '@tanstack/query-core': 4.29.5
-      jotai: 2.0.4(react@18.2.0)
+      jotai: 2.1.0(react@18.2.0)
     dev: true
 
-  /jotai@2.0.4(react@18.2.0):
-    resolution: {integrity: sha512-XkR1Jtm4a2iKV/7fdB3rNHjJz8FkkDMVczqiAok7lt8W4F69l/ZQkPGWSEV+hJOJXRn27k6XYKOoKEQIwBuAMA==}
+  /jotai@2.1.0(react@18.2.0):
+    resolution: {integrity: sha512-fR82PtHAmEQrc/daMEYGc4EteW96/b6wodtDSCzLvoJA/6y4YG70er4hh2f8CYwYjqwQ0eZUModGfG4DmwkTyQ==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       react: '>=17.0.0'
@@ -13077,6 +13090,32 @@ packages:
       webpack: 5.81.0(@swc/core@1.3.55)(esbuild@0.17.18)
     dev: true
 
+  /terser-webpack-plugin@5.3.8(@swc/core@1.3.55)(esbuild@0.17.18)(webpack@5.82.0):
+    resolution: {integrity: sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.18
+      '@swc/core': 1.3.55
+      esbuild: 0.17.18
+      jest-worker: 27.5.1
+      schema-utils: 3.1.2
+      serialize-javascript: 6.0.1
+      terser: 5.17.1
+      webpack: 5.82.0(@swc/core@1.3.55)(esbuild@0.17.18)
+    dev: true
+
   /terser@5.17.1:
     resolution: {integrity: sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==}
     engines: {node: '>=10'}
@@ -13894,6 +13933,46 @@ packages:
       schema-utils: 3.1.2
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.7(@swc/core@1.3.55)(esbuild@0.17.18)(webpack@5.81.0)
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: true
+
+  /webpack@5.82.0(@swc/core@1.3.55)(esbuild@0.17.18):
+    resolution: {integrity: sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 1.0.1
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/wasm-edit': 1.11.5
+      '@webassemblyjs/wasm-parser': 1.11.5
+      acorn: 8.8.2
+      acorn-import-assertions: 1.8.0(acorn@8.8.2)
+      browserslist: 4.21.5
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.13.0
+      es-module-lexer: 1.2.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.1.2
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.8(@swc/core@1.3.55)(esbuild@0.17.18)(webpack@5.82.0)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/hooks/useInternalAtomValue.ts
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/hooks/useInternalAtomValue.ts
@@ -63,14 +63,11 @@ export function useInternalAtomValue<Value>(atom: Atom<Value>) {
   }
 
   useEffect(() => {
-    if (!userStore.dev_subscribe_state) return;
+    const devSubscribeStore: Store['dev_subscribe_store'] =
+      // @ts-expect-error dev_subscribe_state is deprecated in <= 2.0.3
+      userStore?.dev_subscribe_store || userStore?.dev_subscribe_state;
 
-    // FIXME replace this with `store.dev_subscribe_store` check after next minor Jotai 2.1.0?
-    let devSubscribeStore = userStore.dev_subscribe_state;
-
-    if (typeof userStore.dev_subscribe_store === 'function') {
-      devSubscribeStore = userStore.dev_subscribe_store;
-    }
+    if (!devSubscribeStore) return;
 
     const atomSubCb = <AtomSubscribeFunction>(() => {
       if (typeof delay === 'number') {
@@ -84,7 +81,7 @@ export function useInternalAtomValue<Value>(atom: Atom<Value>) {
     atomSubCb.isJotaiDevTools = true;
 
     const devSubCb = (
-      type?: Parameters<Parameters<typeof userStore.dev_subscribe_store>[0]>[0],
+      type?: Parameters<Parameters<typeof devSubscribeStore>[0]>[0],
     ) => {
       if (type !== 'unsub') {
         return;

--- a/src/utils/useAtomsDebugValue.ts
+++ b/src/utils/useAtomsDebugValue.ts
@@ -43,21 +43,21 @@ export const useAtomsDebugValue = (options?: Options) => {
   const store = useStore(options);
   const [atoms, setAtoms] = useState<Atom<unknown>[]>([]);
   useEffect(() => {
-    if (!enabled) {
+    const devSubscribeStore: Store['dev_subscribe_store'] =
+      // @ts-expect-error dev_subscribe_state is deprecated in <= 2.0.3
+      store?.dev_subscribe_store || store?.dev_subscribe_state;
+
+    if (!enabled || !devSubscribeStore) {
       return;
     }
     const callback = () => {
       setAtoms(Array.from(store.dev_get_mounted_atoms?.() || []));
     };
     // FIXME replace this with `store.dev_subscribe_store` check after next minor Jotai 2.1.0?
-    let devSubscribeStore = store.dev_subscribe_state;
-
-    if (typeof store.dev_subscribe_store !== 'function') {
+    if (!('dev_subscribe_store' in store)) {
       console.warn(
         "[DEPRECATION-WARNING] Jotai version you're using contains deprecated dev-only properties that will be removed soon. Please update to the latest version of Jotai.",
       );
-    } else {
-      devSubscribeStore = store.dev_subscribe_store;
     }
 
     const unsubscribe = devSubscribeStore?.(callback);


### PR DESCRIPTION
- Add backward compatible store support for `<=2.1.0`