### PR TITLE
feat: use atom keys as debug label

### DIFF
--- a/__tests__/devtools/AtomViewer.test.tsx
+++ b/__tests__/devtools/AtomViewer.test.tsx
@@ -16,6 +16,8 @@ const BasicAtomsWithDevTools = () => {
     [countAtom],
   );
 
+  doubleAtom.debugLabel = 'doubleCountAtom';
+
   useAtomValue(countAtom);
   useAtomValue(doubleAtom);
   return <DevTools isInitialOpen={true} />;
@@ -45,7 +47,7 @@ describe('DevTools - AtomViewer', () => {
       const { container } = customRender(<BasicAtomsWithDevTools />);
       expect(screen.getByText('countAtom')).toBeInTheDocument();
       // We did not add `debugLabel` to `doubleAtom` so it should be unlabeled
-      expect(screen.getByText('<unlabeled-atom>')).toBeInTheDocument();
+      expect(screen.getByText('doubleCountAtom')).toBeInTheDocument();
       expect(container).toMatchSnapshot();
     });
 
@@ -73,6 +75,8 @@ describe('DevTools - AtomViewer', () => {
           [countAtom, privateAtom],
         );
 
+        doubleAtom.debugLabel = 'doubleCountAtom';
+
         useAtomValue(countAtom);
         useAtomValue(doubleAtom);
         useAtomValue(privateAtom);
@@ -91,7 +95,7 @@ describe('DevTools - AtomViewer', () => {
         customRender(<PrivateAtomsWithDevTools />);
         expect(screen.queryByText('privateAtom')).not.toBeInTheDocument();
         expect(screen.getByText('countAtom')).toBeInTheDocument();
-        expect(screen.getByText('<unlabeled-atom>')).toBeInTheDocument();
+        expect(screen.getByText('doubleCountAtom')).toBeInTheDocument();
       });
 
       it('should render private atoms when shouldShowPrivateAtoms is marked as true', async () => {
@@ -122,7 +126,7 @@ describe('DevTools - AtomViewer', () => {
 
         expect(screen.getByText('Dependents')).toBeInTheDocument();
         expect(
-          screen.queryByTestId('dependents-list-item-<unlabeled-atom>-0'),
+          screen.queryByTestId('dependents-list-item-doubleCountAtom-0'),
         ).toBeInTheDocument();
         expect(
           screen.queryByTestId('dependents-list-item-privateAtom-0'),
@@ -155,7 +159,7 @@ describe('DevTools - AtomViewer', () => {
 
         expect(screen.getByText('Dependents')).toBeInTheDocument();
         expect(
-          screen.getByTestId('dependents-list-item-<unlabeled-atom>-0'),
+          screen.getByTestId('dependents-list-item-doubleCountAtom-0'),
         ).toBeInTheDocument();
         expect(container).toMatchSnapshot();
       });
@@ -166,16 +170,20 @@ describe('DevTools - AtomViewer', () => {
         const { container } = customRender(<BasicAtomsWithDevTools />);
 
         await act(async () => {
-          await userEvent.type(screen.getByLabelText('Search'), 'count');
+          await userEvent.type(
+            screen.getByLabelText('Search'),
+            'doubleCountAtom',
+          );
         });
 
         expect(
           screen.queryByTestId('atom-list-no-atoms-found-message'),
         ).not.toBeInTheDocument();
-        expect(screen.getByText('countAtom')).toBeInTheDocument();
-        expect(screen.queryByText('<unlabeled-atom>')).not.toBeInTheDocument();
+        expect(screen.queryByText('countAtom')).not.toBeInTheDocument();
+        expect(screen.getByText('doubleCountAtom')).toBeInTheDocument();
         expect(container).toMatchSnapshot();
       });
+
       it('should display an error if no atoms are found', async () => {
         const { container } = customRender(<BasicAtomsWithDevTools />);
 
@@ -186,7 +194,7 @@ describe('DevTools - AtomViewer', () => {
           screen.getByTestId('atom-list-no-atoms-found-message'),
         ).toHaveTextContent('No Atoms found!');
         expect(screen.queryByText('countAtom')).not.toBeInTheDocument();
-        expect(screen.queryByText('<unlabeled-atom>')).not.toBeInTheDocument();
+        expect(screen.queryByText('doubleCountAtom')).not.toBeInTheDocument();
         expect(container).toMatchSnapshot();
       });
     });
@@ -308,7 +316,7 @@ describe('DevTools - AtomViewer', () => {
 
         expect(screen.getByText('Dependents')).toBeInTheDocument();
         expect(
-          screen.getByTestId('dependents-list-item-<unlabeled-atom>-0'),
+          screen.getByTestId('dependents-list-item-doubleCountAtom-0'),
         ).toBeInTheDocument();
         expect(container).toMatchSnapshot();
       });
@@ -317,7 +325,7 @@ describe('DevTools - AtomViewer', () => {
         const { container } = render(<BasicAtomsWithDevTools />);
 
         await act(async () => {
-          await userEvent.click(screen.getByText('<unlabeled-atom>'));
+          await userEvent.click(screen.getByText('doubleCountAtom'));
         });
 
         expect(screen.getByText('Atom Details')).toBeInTheDocument();

--- a/__tests__/devtools/__snapshots__/AtomViewer.test.tsx.snap
+++ b/__tests__/devtools/__snapshots__/AtomViewer.test.tsx.snap
@@ -1674,7 +1674,7 @@ exports[`DevTools - AtomViewer Atom details Raw value should display an error wh
                     <div
                       class="emotion-8 emotion-56"
                     >
-                      &lt;unlabeled-atom&gt;
+                      doubleCountAtom
                     </div>
                   </span>
                   <span
@@ -1862,10 +1862,10 @@ exports[`DevTools - AtomViewer Atom details Raw value should display an error wh
                       <span>
                         <code
                           class="emotion-97 emotion-98"
-                          data-testid="dependents-list-item-<unlabeled-atom>-0"
+                          data-testid="dependents-list-item-doubleCountAtom-0"
                           dir="ltr"
                         >
-                          &lt;unlabeled-atom&gt;
+                          doubleCountAtom
                         </code>
                       </span>
                     </div>
@@ -3464,7 +3464,7 @@ exports[`DevTools - AtomViewer Atom details Raw value should display atom detail
                     <div
                       class="emotion-8 emotion-56"
                     >
-                      &lt;unlabeled-atom&gt;
+                      doubleCountAtom
                     </div>
                   </span>
                   <span
@@ -3686,10 +3686,10 @@ exports[`DevTools - AtomViewer Atom details Raw value should display atom detail
                       <span>
                         <code
                           class="emotion-97 emotion-98"
-                          data-testid="dependents-list-item-<unlabeled-atom>-0"
+                          data-testid="dependents-list-item-doubleCountAtom-0"
                           dir="ltr"
                         >
-                          &lt;unlabeled-atom&gt;
+                          doubleCountAtom
                         </code>
                       </span>
                     </div>
@@ -5258,7 +5258,7 @@ exports[`DevTools - AtomViewer Atom details Raw value should display the depende
                     <div
                       class="emotion-8 emotion-56"
                     >
-                      &lt;unlabeled-atom&gt;
+                      doubleCountAtom
                     </div>
                   </span>
                   <span
@@ -5363,10 +5363,10 @@ exports[`DevTools - AtomViewer Atom details Raw value should display the depende
                   </div>
                   <code
                     class="emotion-97 emotion-98"
-                    data-testid="display-detail-item-value-<unlabeled-atom>"
+                    data-testid="display-detail-item-value-doubleCountAtom"
                     dir="ltr"
                   >
-                    &lt;unlabeled-atom&gt;
+                    doubleCountAtom
                   </code>
                 </div>
                 <div
@@ -7825,7 +7825,7 @@ exports[`DevTools - AtomViewer List of atoms Search should search for atoms corr
                   id="jotai-devtools-atom-debug-search-input"
                   placeholder="atom debug label"
                   type="text"
-                  value="count"
+                  value="doubleCountAtom"
                 />
               </div>
             </div>
@@ -7845,7 +7845,7 @@ exports[`DevTools - AtomViewer List of atoms Search should search for atoms corr
                     <div
                       class="emotion-8 emotion-56"
                     >
-                      countAtom
+                      doubleCountAtom
                     </div>
                   </span>
                   <span
@@ -9523,7 +9523,7 @@ exports[`DevTools - AtomViewer List of atoms private atoms should hide private a
                     <div
                       class="emotion-8 emotion-56"
                     >
-                      &lt;unlabeled-atom&gt;
+                      doubleCountAtom
                     </div>
                   </span>
                   <span
@@ -9745,10 +9745,10 @@ exports[`DevTools - AtomViewer List of atoms private atoms should hide private a
                       <span>
                         <code
                           class="emotion-97 emotion-98"
-                          data-testid="dependents-list-item-<unlabeled-atom>-0"
+                          data-testid="dependents-list-item-doubleCountAtom-0"
                           dir="ltr"
                         >
-                          &lt;unlabeled-atom&gt;
+                          doubleCountAtom
                         </code>
                       </span>
                     </div>
@@ -11355,7 +11355,7 @@ exports[`DevTools - AtomViewer List of atoms private atoms should mark private a
                     <div
                       class="emotion-8 emotion-56"
                     >
-                      &lt;unlabeled-atom&gt;
+                      doubleCountAtom
                     </div>
                   </span>
                   <span
@@ -11650,10 +11650,10 @@ exports[`DevTools - AtomViewer List of atoms private atoms should mark private a
                       <span>
                         <code
                           class="emotion-115 emotion-116"
-                          data-testid="dependents-list-item-<unlabeled-atom>-0"
+                          data-testid="dependents-list-item-doubleCountAtom-0"
                           dir="ltr"
                         >
-                          &lt;unlabeled-atom&gt;
+                          doubleCountAtom
                         </code>
                       </span>
                     </div>
@@ -12929,7 +12929,7 @@ exports[`DevTools - AtomViewer List of atoms should render atom viewer with corr
                     <div
                       class="emotion-8 emotion-56"
                     >
-                      &lt;unlabeled-atom&gt;
+                      doubleCountAtom
                     </div>
                   </span>
                   <span

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@types/node": "^18.16.2",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.1",
+    "@types/testing-library__jest-dom": "^5.14.5",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "babel-loader": "^9.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18.2.1
     version: 18.2.1
+  '@types/testing-library__jest-dom':
+    specifier: ^5.14.5
+    version: 5.14.5
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.59.1
     version: 5.59.1(@typescript-eslint/parser@5.59.1)(eslint@8.39.0)(typescript@5.0.4)

--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomDetail/components/AtomDependentsList.tsx
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomDetail/components/AtomDependentsList.tsx
@@ -3,7 +3,7 @@ import { Box, Code, List, Text } from '@mantine/core';
 import { AnyAtom } from 'src/types';
 import { useDevToolsOptionsValue } from '../../../../../../../../atoms/devtools-options';
 import { useAtomsSnapshots } from '../../../../../../../../hooks/useAtomsSnapshots';
-import { parseDebugLabel } from '../../../../../../../../utils/parse-debug-label';
+import { atomToPrintable } from '../../../../../../../../utils/';
 
 type AtomDependentsListProps = {
   atom: AnyAtom;
@@ -33,10 +33,10 @@ export const AtomDependentsList = ({
 
   const listOfDependents = React.useMemo(
     () =>
-      depsForAtom.map((value, i) => {
-        const parsedDebugLabel = parseDebugLabel(value?.debugLabel);
+      depsForAtom.map((atom, i) => {
+        const parsedDebugLabel = atomToPrintable(atom);
         return (
-          <List.Item key={`${i}-${value.toString()}-dependents-list`}>
+          <List.Item key={`${i}-${atom.toString()}-dependents-list`}>
             <Code data-testid={`dependents-list-item-${parsedDebugLabel}-${i}`}>
               {parsedDebugLabel}
             </Code>

--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomDetail/components/AtomMetaDetails.tsx
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomDetail/components/AtomMetaDetails.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Box, Code, MantineColor, Text, Title, Tooltip } from '@mantine/core';
 import { AtomValueType } from '../../../../../../../../utils/get-type-of-atom-value';
-import { parseDebugLabel } from '../../../../../../../../utils/parse-debug-label';
 
 type AtomDetailItemProps = {
   label: string;
@@ -52,10 +51,7 @@ export const AtomMetaDetails = React.memo(
         <Text fw="bold" mb={10}>
           Meta
         </Text>
-        <DisplayAtomDetailsItem
-          label="Debug Label"
-          value={parseDebugLabel(debugLabel)}
-        />
+        <DisplayAtomDetailsItem label="Debug Label" value={debugLabel} />
         <DisplayAtomDetailsItem label="Value type" value={atomValueType} />
         {isAtomPrivate && (
           <DisplayAtomDetailsItem label="Private" value={'Yes'} color={'red'} />

--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomDetail/components/DisplayAtomDetails.tsx
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomDetail/components/DisplayAtomDetails.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Stack } from '@mantine/core';
 import { AnyAtom } from 'src/types';
-import { getTypeOfAtomValue } from '../../../../../../../../utils/get-type-of-atom-value';
+import {
+  atomToPrintable,
+  getTypeOfAtomValue,
+} from '../../../../../../../../utils';
 import { useInternalAtomValue } from '../../../hooks/useInternalAtomValue';
 import { AtomDependentsList } from './AtomDependentsList';
 import { AtomMetaDetails } from './AtomMetaDetails';
@@ -18,7 +21,7 @@ export const DisplayAtomDetails = ({ atom }: DisplayAtomDetailsProps) => {
   return (
     <Stack h="auto">
       <AtomMetaDetails
-        debugLabel={atom?.debugLabel}
+        debugLabel={atomToPrintable(atom)}
         atomValueType={atomValueType}
         isAtomPrivate={atom?.debugPrivate}
       />

--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomList/AtomList.tsx
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomList/AtomList.tsx
@@ -4,6 +4,7 @@ import { IconAlertCircle } from '@tabler/icons-react';
 import { useAtom, useAtomValue } from 'jotai/react';
 import { useSyncSnapshotValuesToAtom } from '../../../../../../../hooks/useAtomsSnapshots';
 import { useDevtoolsJotaiStoreOptions } from '../../../../../../../internal-jotai-store';
+import { atomToPrintable } from '../../../../../../../utils';
 import {
   filteredValuesAtom,
   searchInputAtom,
@@ -93,7 +94,7 @@ export const AtomList = () => {
         return (
           <AtomListItem
             key={`atom-list-item-${atom.toString() + i}`}
-            label={atom.debugLabel}
+            label={atomToPrintable(atom)}
             onClick={handleOnClick}
             pos={i}
             isActive={selectedAtomData?.atomKey === atom.toString()}

--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomList/components/AtomListItem.tsx
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomList/components/AtomListItem.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { NavLink, Sx, Text } from '@mantine/core';
 import { IconChevronRight } from '@tabler/icons-react';
 import { useThemeMode } from '../../../../../../../../hooks/useThemeMode';
-import { parseDebugLabel } from '../../../../../../../../utils/parse-debug-label';
 
 type AtomListItemProps = {
   label?: string | undefined;
@@ -26,7 +25,7 @@ export const AtomListItem = React.memo(
       <NavLink
         label={React.useMemo(
           () => (
-            <Text sx={monoSpaceFonts}>{parseDebugLabel(label)}</Text>
+            <Text sx={monoSpaceFonts}>{label}</Text>
           ),
           [label],
         )}

--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/utils/filter-atoms-by-string.ts
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/utils/filter-atoms-by-string.ts
@@ -1,5 +1,5 @@
 import { ValuesAtomTuple } from 'src/types';
-import { parseDebugLabel } from './../../../../../../utils/parse-debug-label';
+import { atomToPrintable } from '../../../../../../utils';
 
 export const filterAtomsByString = (
   searchString: string,
@@ -11,7 +11,7 @@ export const filterAtomsByString = (
   }
 
   return defaultAtoms.filter(([atomTuple]) => {
-    const parsedDebugLabel = parseDebugLabel(atomTuple?.debugLabel);
+    const parsedDebugLabel = atomToPrintable(atomTuple);
     const normalizedLabel = parsedDebugLabel.toLocaleLowerCase();
     return normalizedLabel.includes(normalizedStr);
   });

--- a/src/DevTools/constants.ts
+++ b/src/DevTools/constants.ts
@@ -1,7 +1,3 @@
-// storing this as a constants to reuse it across the Shell
-// This could be searched by user on the Atom viewer as well
-export const unlabeledAtomLabel = '<unlabeled-atom>';
-
 export const shellStyleDefaults = {
   minHeight: 200, // in px
   maxHeight: '90%',

--- a/src/DevTools/utils/atom-to-printable.ts
+++ b/src/DevTools/utils/atom-to-printable.ts
@@ -1,0 +1,12 @@
+import { AnyAtom } from '../../types';
+
+/**
+ * We label atoms with debugLabel to make it easier to identify them in the DevTools + avoid the naming collisions
+ * when showing multiple atoms that are not labeled
+ *
+ * @param atom AnyAtom
+ * @returns printable string based on the atom's debugLabel or a default string
+ */
+export const atomToPrintable = (atom: AnyAtom): string => {
+  return atom.debugLabel ? atom.debugLabel : `<unlabeled-${atom}>`;
+};

--- a/src/DevTools/utils/index.ts
+++ b/src/DevTools/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './get-type-of-atom-value';
-export * from './parse-debug-label';
+export * from './atom-to-printable';
 export * from './stringify-atom-value';
 export * from './create-memoized-emotion-cache';
+export * from './generate-local-storage-key';

--- a/src/DevTools/utils/parse-debug-label.ts
+++ b/src/DevTools/utils/parse-debug-label.ts
@@ -1,5 +1,0 @@
-import { unlabeledAtomLabel } from '../constants';
-
-export const parseDebugLabel = (label?: string): string => {
-  return label || unlabeledAtomLabel;
-};

--- a/src/stories/Default/Playground/Playground.stories.tsx
+++ b/src/stories/Default/Playground/Playground.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MantineProvider } from '@mantine/core';
 import { Meta, StoryObj } from '@storybook/react';
-import { DevTools, DevToolsProps } from '../../../DevTools';
+import { DevTools, DevToolsProps } from '../../../';
 import { Playground } from './Playground';
 
 export default {


### PR DESCRIPTION
Improve how we handle unlabeled atoms. We'll use a unique atom key to enable a better debugging experience. 

It also prepares us for Time Travel features that require each label to be unique. 