### PR TITLE
refactor: extract action list item to its own component

### DIFF
--- a/src/DevTools/Extension/components/Shell/components/ActionListItem.tsx
+++ b/src/DevTools/Extension/components/Shell/components/ActionListItem.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { NavLink, Sx, Text } from '@mantine/core';
 import { IconChevronRight } from '@tabler/icons-react';
-import { useThemeMode } from '../../../../../../../../hooks/useThemeMode';
+import { useThemeMode } from '../../../../hooks/useThemeMode';
 
-type AtomListItemProps = {
+type ActionListItemProps = {
   label?: string | undefined;
-  onClick: (pos: number) => void;
-  atomKey: string;
-  pos: number;
+  id: string | number;
+  onClick: (id: string | number) => void;
   isActive: boolean;
 };
 
@@ -19,8 +18,10 @@ const navLinkStyles: Sx = (theme) => ({
   borderRadius: theme.radius.md,
 });
 
-export const AtomListItem = React.memo(
-  ({ label, onClick, pos, isActive }: AtomListItemProps) => {
+export const ActionListItem = React.memo(
+  ({ label, onClick, id, isActive }: ActionListItemProps) => {
+    const handleOnClick = React.useCallback(() => onClick(id), [onClick, id]);
+
     return (
       <NavLink
         label={React.useMemo(
@@ -33,7 +34,7 @@ export const AtomListItem = React.memo(
         sx={navLinkStyles}
         active={isActive}
         color={useThemeMode('dark', 'gray')}
-        onClick={React.useCallback(() => onClick(pos), [onClick, pos])}
+        onClick={handleOnClick}
         rightSection={React.useMemo(
           () => (
             <IconChevronRight size={12} stroke={1.5} />
@@ -45,4 +46,4 @@ export const AtomListItem = React.memo(
   },
 );
 
-AtomListItem.displayName = 'AtomListItem';
+ActionListItem.displayName = 'ActionListItem';

--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomList/AtomList.tsx
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomList/AtomList.tsx
@@ -5,12 +5,12 @@ import { useAtom, useAtomValue } from 'jotai/react';
 import { useSyncSnapshotValuesToAtom } from '../../../../../../../hooks/useAtomsSnapshots';
 import { useDevtoolsJotaiStoreOptions } from '../../../../../../../internal-jotai-store';
 import { atomToPrintable } from '../../../../../../../utils';
+import { ActionListItem } from '../../../ActionListItem';
 import {
   filteredValuesAtom,
   searchInputAtom,
   selectedAtomAtom,
 } from '../../atoms';
-import { AtomListItem } from './components/AtomListItem';
 
 const textStyles: Sx = {
   position: 'sticky',
@@ -67,7 +67,11 @@ export const AtomList = () => {
   }, [values]);
 
   const handleOnClick = React.useCallback(
-    (pos: number) => {
+    (pos: string | number) => {
+      if (typeof pos === 'string') {
+        throw new Error('Invalid atom position, must be a number');
+      }
+
       if (!valuesRef.current[pos]) {
         // This should almost never occur
         // Atom pos and valuesRef.current are out-of-sync if it occurs
@@ -91,14 +95,14 @@ export const AtomList = () => {
   const atomItems = React.useMemo(
     () =>
       values.map(([atom], i) => {
+        const atomKey = atom.toString();
         return (
-          <AtomListItem
-            key={`atom-list-item-${atom.toString() + i}`}
+          <ActionListItem
+            key={`atom-list-item-${atomKey + i}`}
             label={atomToPrintable(atom)}
             onClick={handleOnClick}
-            pos={i}
-            isActive={selectedAtomData?.atomKey === atom.toString()}
-            atomKey={atom.toString()}
+            id={i}
+            isActive={selectedAtomData?.atomKey === atomKey}
           />
         );
       }),


### PR DESCRIPTION
Extract out action list item components to be more reusable in efforts. This eases our efforts for Time Travel functionality.