### PR TITLE
fix: add trigger button to global css

### DIFF
--- a/src/DevTools/DevTools.tsx
+++ b/src/DevTools/DevTools.tsx
@@ -12,7 +12,11 @@ import {
   DevToolsOptions,
   useSetDevToolsOptions,
 } from './atoms/devtools-options';
-import { Extension, ExtensionProps } from './Extension';
+import {
+  Extension,
+  ExtensionProps,
+  shellTriggerButtonStyles,
+} from './Extension';
 import { fontCss } from './fonts';
 import { InternalDevToolsContext } from './internal-jotai-store';
 import { createMemoizedEmotionCache } from './utils';
@@ -40,6 +44,7 @@ const theme: MantineThemeOverride = {
       MozOsxFontSmoothing: 'grayscale',
       fontSize: theme.fontSizes.md,
     },
+    ...shellTriggerButtonStyles,
   }),
 };
 

--- a/src/DevTools/Extension/Extension.tsx
+++ b/src/DevTools/Extension/Extension.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { ActionIcon, Sx } from '@mantine/core';
+import { ActionIcon } from '@mantine/core';
+import type { CSSObject } from '@mantine/core';
 import { useAtom, useSetAtom } from 'jotai/react';
 import { Store } from '../../types';
 import { isShellOpenAtom } from '../atoms/is-shell-open-atom';
@@ -10,18 +11,23 @@ import { logo } from './assets/logo';
 import { Shell } from './components/Shell';
 import useSyncSnapshotHistory from './components/Shell/components/TimeTravel/useSyncSnapshotHistory';
 
-const shellTriggerButtonStyles: Sx = () => ({
-  position: 'fixed',
-  left: 10,
-  bottom: 10,
-  borderRadius: '50%',
-  width: '4rem',
-  height: '4rem',
-  zIndex: 99999,
-  img: {
-    height: '2rem',
+const shellTriggerButtonClassName = 'jotai-devtools-trigger-button';
+
+export const shellTriggerButtonStyles: CSSObject = {
+  [`.${shellTriggerButtonClassName}`]: {
+    position: 'fixed',
+    left: 10,
+    bottom: 10,
+    borderRadius: '50%',
+    borderWidth: 0,
+    width: '4rem',
+    height: '4rem',
+    zIndex: 99999,
+    img: {
+      height: '2rem',
+    },
   },
-});
+};
 
 const ShellTriggerButton = React.forwardRef<HTMLButtonElement>((_, ref) => {
   const setIsShellOpen = useSetAtom(
@@ -34,10 +40,9 @@ const ShellTriggerButton = React.forwardRef<HTMLButtonElement>((_, ref) => {
       variant="filled"
       color={useThemeMode('dark', 'gray.3')}
       onClick={() => setIsShellOpen(true)}
-      sx={shellTriggerButtonStyles}
       ref={ref}
       title="Open Jotai Devtools"
-      className="jotai-devtools-trigger-button"
+      className={shellTriggerButtonClassName}
     >
       <img src={logo} alt="Jotai Mascot" />
     </ActionIcon>


### PR DESCRIPTION
This is a small presentational fix for SSR.

#### Changes
- move the trigger button css to the theme `globalStyles`

#### Details
When server rendering, the trigger button has no styles applied yet, so you get this jank when refreshing the page.
Note I made an addition of `borderWitdth: 0` to prevent the user agent border style showing up.

There a few ways you could do this, but I thought it made sense to keep the styles in the `Extension.tsx` file and import them.

Here's the before/after with a `create-next-app` app:

https://github.com/jotaijs/jotai-devtools/assets/13904763/2ed647b7-de41-45d8-9efe-2c5ed4bd8a29


https://github.com/jotaijs/jotai-devtools/assets/13904763/93dfb8a4-e4a8-4e2c-8e76-2761880f1527

