### PR TITLE
feat: hide private atoms in utils

### DIFF
--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/atoms.ts
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/atoms.ts
@@ -1,10 +1,8 @@
 import { atom } from 'jotai/vanilla';
 import { atomWithDefault } from 'jotai/vanilla/utils';
 import { AnyAtom, ValuesAtomTuple } from 'src/types';
-import { devToolsOptionsAtom } from '../../../../../atoms/devtools-options';
 import { valuesAtom } from '../../../../../atoms/values-atom';
 import { filterAtomsByString } from './utils/filter-atoms-by-string';
-import { filterPrivateAtoms } from './utils/filter-private-atoms';
 
 type SelectedAtomAtomData = { atomKey: string; atom: AnyAtom };
 
@@ -20,12 +18,6 @@ export const filteredValuesAtom = atomWithDefault<ValuesAtomTuple[]>((get) => {
     get(searchInputInternalValueAtom),
     get(valuesAtom),
   );
-
-  const { shouldShowPrivateAtoms } = get(devToolsOptionsAtom);
-  if (!shouldShowPrivateAtoms) {
-    const filteredByPrivate = filterPrivateAtoms(filteredByString);
-    return filteredByPrivate;
-  }
 
   return filteredByString;
 });

--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomDetail/components/AtomDependentsList.tsx
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/components/AtomDetail/components/AtomDependentsList.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Box, Code, List, Text } from '@mantine/core';
 import { AnyAtom } from 'src/types';
-import { useDevToolsOptionsValue } from '../../../../../../../../atoms/devtools-options';
 import { useAtomsSnapshots } from '../../../../../../../../hooks/useAtomsSnapshots';
 import { atomToPrintable } from '../../../../../../../../utils/';
 
@@ -13,7 +12,6 @@ export const AtomDependentsList = ({
   atom,
 }: AtomDependentsListProps): JSX.Element => {
   const { dependents } = useAtomsSnapshots();
-  const devtoolsOptions = useDevToolsOptionsValue();
 
   const depsForAtom = React.useMemo(() => {
     const arr = Array.from(dependents.get(atom) || []);
@@ -21,15 +19,8 @@ export const AtomDependentsList = ({
       (a) => a.toString() !== atom.toString(),
     );
 
-    if (!devtoolsOptions.shouldShowPrivateAtoms) {
-      const filteredPrivateAtoms = filteredCurrentAtom.filter(
-        (a) => !a?.debugPrivate,
-      );
-      return filteredPrivateAtoms;
-    }
-
     return filteredCurrentAtom;
-  }, [dependents, devtoolsOptions.shouldShowPrivateAtoms, atom]);
+  }, [dependents, atom]);
 
   const listOfDependents = React.useMemo(
     () =>

--- a/src/DevTools/Extension/components/Shell/components/AtomViewer/utils/filter-private-atoms.ts
+++ b/src/DevTools/Extension/components/Shell/components/AtomViewer/utils/filter-private-atoms.ts
@@ -1,5 +1,0 @@
-import { ValuesAtomTuple } from '../../../../../../../types';
-
-export const filterPrivateAtoms = (atoms: ValuesAtomTuple[]) => {
-  return atoms.filter(([atom]) => !atom?.debugPrivate);
-};

--- a/src/DevTools/hooks/useAtomsSnapshots.ts
+++ b/src/DevTools/hooks/useAtomsSnapshots.ts
@@ -1,12 +1,15 @@
 import { useEffect, useMemo } from 'react';
-import { Options } from 'src/types';
 import { useAtomsSnapshot as useJotaiAtomsSnapshot } from '../../utils';
+import { useDevToolsOptionsValue } from '../atoms/devtools-options';
 import { useSnapshotValues } from '../atoms/values-atom';
 import { useUserStore } from './useUserStore';
 
+type SnapshotOptions = Parameters<typeof useJotaiAtomsSnapshot>[0];
+
 export const useAtomsSnapshots = () => {
+  const { shouldShowPrivateAtoms } = useDevToolsOptionsValue();
   const store = useUserStore();
-  const opts: Options = { store };
+  const opts: SnapshotOptions = { store, shouldShowPrivateAtoms };
 
   const currentSnapshots = useJotaiAtomsSnapshot(opts);
   return currentSnapshots;

--- a/src/utils/useAtomsDevtools.ts
+++ b/src/utils/useAtomsDevtools.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from 'react';
-import { AnyAtom, AnyAtomValue, AtomsSnapshot, Options } from '../types';
+import { AnyAtom, AnyAtomValue, AtomsSnapshot } from '../types';
 import {
   Connection,
   createReduxConnection,
 } from './redux-extension/createReduxConnection';
 import { getReduxExtension } from './redux-extension/getReduxExtension';
-import { useAtomsSnapshot } from './useAtomsSnapshot';
+import { SnapshotOptions, useAtomsSnapshot } from './useAtomsSnapshot';
 import { useGotoAtomsSnapshot } from './useGotoAtomsSnapshot';
 
 const atomToPrintable = (atom: AnyAtom) =>
@@ -26,7 +26,7 @@ const getDevtoolsState = (atomsSnapshot: AtomsSnapshot) => {
   };
 };
 
-type DevtoolsOptions = Options & {
+type DevtoolsOptions = SnapshotOptions & {
   enabled?: boolean;
 };
 


### PR DESCRIPTION
Hides private atoms in `useAtomsSnapshot` and `useAtomsDevtools` hooks, similarly to how `<DevTools />` has done. This can be disabled using the `shouldShowPrivateAtoms` option. As discussed in https://github.com/jotaijs/jotai-devtools/discussions/103

The implementation of this consists of moving the logic from `DevTools` components into the `useAtomsSnapshot`, which is used by both `DevTools` and `useAtomsDevtools`. Now the logic for hiding private atoms is shared by all the tools.