### PR TITLE
Update docs for conditional CSS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,14 @@ and is replaced it with native CSS.
 2. Replace `@emotion/react` with `jotai-devtools/styles.css` in your code
 
 Note that this css file may get included in your production builds please import
-it conditionally if you want to avoid that.
+it conditionally if you want to avoid that, e.g.:
 
 ```diff
 import { DevTools } from 'jotai-devtools';
-+ import 'jotai-devtools/styles.css';
++ 
++ if (process.env.NODE_ENV === 'development') {
++     require('jotai-devtools/styles.css')
++ }
 ```
 
 ### Migrate Jotai to V2


### PR DESCRIPTION
I tried it like this first but it was complaining that an import has to be a top-level declaration:

```typescript
if (process.env.NODE_ENV === 'development') {
    import('jotai-devtools/styles.css')
}
```

I also tried it with `next/dynamic` but no luck there.