### PR TITLE
fix: mantine css leak 

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "lint-staged": "^15.2.5",
     "postcss": "^8.4.38",
     "postcss-loader": "^8.1.1",
+    "postcss-prefix-selector": "^1.16.1",
     "postcss-preset-mantine": "^1.15.0",
     "prettier": "^3.3.1",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ devDependencies:
   postcss-loader:
     specifier: ^8.1.1
     version: 8.1.1(postcss@8.4.38)(typescript@5.4.5)(webpack@5.91.0)
+  postcss-prefix-selector:
+    specifier: ^1.16.1
+    version: 1.16.1(postcss@8.4.38)
   postcss-preset-mantine:
     specifier: ^1.15.0
     version: 1.15.0(postcss@8.4.38)
@@ -11852,6 +11855,14 @@ packages:
     dependencies:
       postcss: 8.4.38
       postcss-selector-parser: 6.1.0
+    dev: true
+
+  /postcss-prefix-selector@1.16.1(postcss@8.4.38):
+    resolution: {integrity: sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==}
+    peerDependencies:
+      postcss: '>4 <9'
+    dependencies:
+      postcss: 8.4.38
     dev: true
 
   /postcss-preset-mantine@1.15.0(postcss@8.4.38):

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,6 +3,7 @@ module.exports = {
     'postcss-preset-mantine': {},
     'postcss-prefix-selector': {
       prefix: '#jotai-devtools-root',
+      includeFiles: [/node_modules\/@mantine/],
       transform(prefix, selector, prefixedSelector) {
         if (selector.startsWith('html') || selector.startsWith('body')) {
           return selector.replace(/^html|^body/, prefix);

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,14 @@
 module.exports = {
   plugins: {
     'postcss-preset-mantine': {},
+    'postcss-prefix-selector': {
+      prefix: '#jotai-devtools-root',
+      transform(prefix, selector, prefixedSelector) {
+        if (selector.startsWith('html') || selector.startsWith('body')) {
+          return selector.replace(/^html|^body/, prefix);
+        }
+        return prefixedSelector;
+      },
+    },
   },
 };


### PR DESCRIPTION
This pull request fixes the issue of CSS leakage from the Mantine component library by scoping its styles within a specific root element.

#### Details:
We used the `postcss-prefix-selector` plugin to add a prefix (`#jotai-devtools-root`) to all Mantine styles. This ensures that Mantine styles are contained and do not affect other parts of the application.

Result of generated `index.css`:
![image](https://github.com/user-attachments/assets/952ba22d-ca7e-4ddd-a958-7aa2b9fb3e37)


#### Testing Instructions:
Test the fix in this repository: [Jotai Devtool Test CSS Leak](https://github.com/Elvincth/jotai-devtool-test-css-leak). Use `pnpm link` to link the dev package.

Thank you!