### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "react": ">=17.0.0"
+    "react": ">=18.0.0"
   },
   "dependencies": {
     "@mantine/code-highlight": "^7.11.2",


### PR DESCRIPTION

The react peerDependencies version should be greater than 18, as the react peerDependencies version for @mantine/hooks is above 18, and it internally uses `useId` that does not exist in React 17

![image](https://github.com/user-attachments/assets/f718fc50-5dde-48b8-93ba-ddd7a6d461e2)
