### PR TITLE
Expose InternalDevTools for production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
   "source": "./src/index.ts",
   "exports": {
     "./package.json": "./package.json",
+    "./internal__devtools": {
+      "import": {
+        "types": "./dist/internal__devtools.d.mts",
+        "default": "./dist/internal__devtools.esm.mjs"
+      },
+      "types": "./dist/internal__devtools.d.ts",
+      "default": "./dist/internal__devtools.cjs.js"
+    },
     ".": {
       "import": {
         "types": "./dist/index.d.mts",

--- a/src/DevTools/DevTools.tsx
+++ b/src/DevTools/DevTools.tsx
@@ -127,13 +127,9 @@ const DevToolsProvider = ({ children }: React.PropsWithChildren) => {
 };
 
 export const InternalDevTools = (props: DevToolsProps): JSX.Element | null => {
-  if (__DEV__) {
-    return (
-      <DevToolsProvider>
-        <DevToolsMain {...props} />
-      </DevToolsProvider>
-    );
-  }
-
-  return <></>;
+  return (
+    <DevToolsProvider>
+      <DevToolsMain {...props} />
+    </DevToolsProvider>
+  );
 };


### PR DESCRIPTION
This PR is a follow-up to the discussion https://github.com/jotaijs/jotai-devtools/discussions/102. It's a proposal that we can discard.

This change will allow developers to include the `InternalDevTools` component in production builds. 
