### PR TITLE
fix: drop support for jotai store v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@
 
 - Debug 🐞 atom values with ease
 - ⏳ Time-travel through your atoms and find bugs faster than before
-  (recommended jotai `>=2.2.0`)
 - Out-of-the-box 🔌 support for async/suspendible atoms
 - Built-in Dark mode 🌗
 - ✅ Supports custom `store`
 - ✅ Works with provider-less mode
 - ✅ Works with Next.js
 - ✅ Supports custom `nonce` for CSP
-- ✅ Hides private atoms with ability to configure (requires Jotai `>=2.0.3`)
+- ✅ Hides private atoms with ability to configure
 - ✅ Tree-shakable and built for non-production environments
 - ✅ Parses all the JavaScript values with JSON Tree view
 - ✅ Diff checking with additions and deletion highlights
@@ -30,7 +29,7 @@
 
 ## ☝️ Prerequisites
 
-- Jotai version `>=2.1.0.`
+- Jotai version `>=2.9.0`
 - React version `>=17.0.0`
 
 ## 📦 Setup

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-watch-typeahead": "^2.2.2",
-    "jotai": "^2.9.1",
+    "jotai": "^2.11.3",
     "jotai-tanstack-query": "^0.7.2",
     "lint-staged": "^15.3.0",
     "postcss": "^8.4.49",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,11 +194,11 @@ devDependencies:
     specifier: ^2.2.2
     version: 2.2.2(jest@29.7.0)
   jotai:
-    specifier: ^2.9.1
-    version: 2.9.1(@types/react@18.3.3)(react@18.3.1)
+    specifier: ^2.11.3
+    version: 2.11.3(@types/react@18.3.3)(react@18.3.1)
   jotai-tanstack-query:
     specifier: ^0.7.2
-    version: 0.7.2(@tanstack/query-core@4.36.1)(jotai@2.9.1)
+    version: 0.7.2(@tanstack/query-core@4.36.1)(jotai@2.11.3)
   lint-staged:
     specifier: ^15.3.0
     version: 15.4.3
@@ -8259,18 +8259,18 @@ packages:
     hasBin: true
     dev: true
 
-  /jotai-tanstack-query@0.7.2(@tanstack/query-core@4.36.1)(jotai@2.9.1):
+  /jotai-tanstack-query@0.7.2(@tanstack/query-core@4.36.1)(jotai@2.11.3):
     resolution: {integrity: sha512-acwJJf4HKgs4c0mtgRJEvdL7jqQnKcT0ARvs33weGysLpQ8L1S3SqPPoMeHuLDz6vREcocsVFRZ5RsB7rJJHZQ==}
     peerDependencies:
       '@tanstack/query-core': '*'
       jotai: '>=1.11.0'
     dependencies:
       '@tanstack/query-core': 4.36.1
-      jotai: 2.9.1(@types/react@18.3.3)(react@18.3.1)
+      jotai: 2.11.3(@types/react@18.3.3)(react@18.3.1)
     dev: true
 
-  /jotai@2.9.1(@types/react@18.3.3)(react@18.3.1):
-    resolution: {integrity: sha512-t4Q7FIqQB3N/1art4OcqdlEtPmQ2h4DNIzTFhvt06WE0kCpQ1QoG+1A1IGTaQBi2KdDRsnywj+ojmHHKgw6PDA==}
+  /jotai@2.11.3(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-B/PsewAQ0UOS5e2+TTWegUPQ3SCLPCjPY24LYUjfn2EorGlluTA2dFjVLgF1+xHLjK9Jit3y5mKHyMG3Xq/GZg==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=17.0.0'

--- a/src/DevTools/internal-jotai-store.ts
+++ b/src/DevTools/internal-jotai-store.ts
@@ -1,10 +1,6 @@
 import { createContext, useContext } from 'react';
-import { createStore } from 'jotai/vanilla';
-import { Store } from 'src/types';
+import type { Store } from 'src/types';
 
-// Don't use this directly in your components
-// use `useDevtoolsJotaiStoreOptions` instead
-export const internalJotaiStore = createStore();
 export const InternalDevToolsContext = createContext<Store | undefined>(
   undefined,
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,11 @@
 import { useStore } from 'jotai/react';
-import type {
-  Atom,
-  WritableAtom,
-  createStore as createStoreV1,
-} from 'jotai/vanilla';
+import type { Atom, WritableAtom, createStore } from 'jotai/vanilla';
 import { INTERNAL_DevStoreRev4, INTERNAL_PrdStore } from 'jotai/vanilla/store';
 
-export type StoreV1 = ReturnType<typeof createStoreV1>;
-export type StoreV2 = INTERNAL_DevStoreRev4 & INTERNAL_PrdStore;
+export type StoreWithoutDevMethods = ReturnType<typeof createStore>;
+export type StoreWithDevMethods = INTERNAL_DevStoreRev4 & INTERNAL_PrdStore;
 
-export type Store = StoreV1 | StoreV2;
+export type Store = StoreWithoutDevMethods | StoreWithDevMethods;
 
 export type Options = Parameters<typeof useStore>[0];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 import { useStore } from 'jotai/react';
 import type { Atom, WritableAtom, createStore } from 'jotai/vanilla';
-import { INTERNAL_DevStoreRev4, INTERNAL_PrdStore } from 'jotai/vanilla/store';
+import type {
+  INTERNAL_DevStoreRev4,
+  INTERNAL_PrdStore,
+} from 'jotai/vanilla/store';
 
 export type StoreWithoutDevMethods = ReturnType<typeof createStore>;
 export type StoreWithDevMethods = INTERNAL_DevStoreRev4 & INTERNAL_PrdStore;

--- a/src/utils/internals/compose-with-devtools.ts
+++ b/src/utils/internals/compose-with-devtools.ts
@@ -4,8 +4,7 @@ import {
   AnyAtomError,
   AnyAtomValue,
   Store,
-  StoreV1,
-  StoreV2,
+  StoreWithDevMethods,
 } from '../../types';
 
 type DevSubscribeStoreListener = (action: {
@@ -34,12 +33,8 @@ type DevToolsStoreMethods = {
 
 type WithDevToolsStore<S extends Store> = S & DevToolsStoreMethods;
 
-const isStoreV2 = (store: Store | undefined): store is StoreV2 => {
+const isDevStore = (store: Store | undefined): store is StoreWithDevMethods => {
   return store ? 'dev4_get_internal_weak_map' in store : false;
-};
-
-const isStoreV1 = (store: Store | undefined): store is StoreV1 => {
-  return !isStoreV2(store);
 };
 
 export const isDevToolsStore = (
@@ -48,9 +43,9 @@ export const isDevToolsStore = (
   return 'subscribeStore' in store;
 };
 
-const __composeV2StoreWithDevTools = (
-  store: StoreV2,
-): WithDevToolsStore<StoreV2> => {
+const __composeDevTools = (
+  store: StoreWithDevMethods,
+): WithDevToolsStore<StoreWithDevMethods> => {
   const { sub, set, get } = store;
   const storeListeners: Set<DevSubscribeStoreListener> = new Set();
 
@@ -159,83 +154,6 @@ const __composeV2StoreWithDevTools = (
   return store as typeof store & DevToolsStoreMethods;
 };
 
-const __composeV1StoreWithDevTools = (
-  store: StoreV1,
-): StoreV1 | WithDevToolsStore<StoreV1> => {
-  if (
-    'dev_subscribe_store' in store &&
-    'dev_get_mounted_atoms' in store &&
-    'dev_get_atom_state' in store &&
-    'dev_get_mounted' in store &&
-    'dev_restore_atoms' in store
-  ) {
-    const {
-      dev_subscribe_store,
-      dev_get_mounted_atoms,
-      dev_get_atom_state,
-      dev_get_mounted,
-      dev_restore_atoms,
-    } = store;
-
-    (store as WithDevToolsStore<typeof store>).subscribeStore = (l) => {
-      const cb: Parameters<typeof dev_subscribe_store>[0] = (action) => {
-        if (action.type === 'write' || action.type === 'async-write') {
-          l({ type: 'set' });
-        }
-
-        if (action.type === 'sub') {
-          l({ type: 'sub' });
-        }
-
-        if (action.type === 'unsub') {
-          l({ type: 'unsub' });
-        }
-
-        if (action.type === 'restore') {
-          l({ type: 'restore' });
-        }
-      };
-
-      return dev_subscribe_store(cb, 2);
-    };
-
-    (store as WithDevToolsStore<typeof store>).getMountedAtoms = () => {
-      return dev_get_mounted_atoms();
-    };
-
-    (store as WithDevToolsStore<typeof store>).getAtomState = (atom) => {
-      const aState = dev_get_atom_state(atom);
-
-      if (aState) {
-        const d = new Set(aState.d.keys());
-        d.delete(atom);
-
-        if ('v' in aState) {
-          return { v: aState.v, d };
-        }
-        if ('e' in aState) {
-          return { e: aState.e, d };
-        }
-
-        return undefined;
-      }
-    };
-
-    (store as WithDevToolsStore<typeof store>).getMountedAtomState = (atom) => {
-      const mounted = dev_get_mounted(atom);
-      return mounted;
-    };
-
-    (store as WithDevToolsStore<typeof store>).restoreAtoms = (values) => {
-      dev_restore_atoms(values);
-    };
-
-    return store as typeof store & DevToolsStoreMethods;
-  }
-
-  return store;
-};
-
 export const composeWithDevTools = (
   store: Store,
 ): typeof store | WithDevToolsStore<typeof store> => {
@@ -244,12 +162,8 @@ export const composeWithDevTools = (
     return store;
   }
 
-  if (isStoreV2(store)) {
-    return __composeV2StoreWithDevTools(store);
-  }
-
-  if (isStoreV1(store)) {
-    return __composeV1StoreWithDevTools(store);
+  if (isDevStore(store)) {
+    return __composeDevTools(store);
   }
 
   return store;


### PR DESCRIPTION
- Drop support for jotai store v1, minimum jotai version required now is `>=2.9.0`
- Unblocks https://github.com/jotaijs/jotai-devtools/pull/170