### PR TITLE
fix: building blocks are included on devStore

### DIFF
--- a/src/utils/internals/compose-with-devtools.ts
+++ b/src/utils/internals/compose-with-devtools.ts
@@ -214,10 +214,7 @@ const createDevStore = (): StoreWithDevMethods => {
     },
   };
 
-  return {
-    ...store,
-    ...devStore,
-  };
+  return Object.assign(store, devStore);
 };
 
 const isDevStore = (store: Store): store is StoreWithDevMethods => {


### PR DESCRIPTION
## Summary
Jotai Devtools has an import side-effect which overrides the createStore method. The new store returned by createStore is created by createDevStore. This store object is created as
```ts
{
  ...store,
  ...devStore,
}
```
But since BUILDING_BLOCKS are not enumerable, the BUILDING_BLOCKS symbol is not assigned to this devStore. This PR fixes this.