### PR TITLE
refactor: support INTERNAL_buildStoreRev3 + drop support for older version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## ☝️ Prerequisites
 
-- Jotai version `>=v2.14.0`
+- Jotai version `>=v2.20.0`
 - React version `>=17.0.0`
 
 ## 📦 Setup

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.1.2",
     "jest-watch-typeahead": "^3.0.1",
-    "jotai": "^2.19.0",
+    "jotai": "https://pkg.pr.new/jotai@3293",
     "jotai-tanstack-query": "^0.9.0",
     "lint-staged": "^16.4.0",
     "postcss": "^8.5.8",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.1.2",
     "jest-watch-typeahead": "^3.0.1",
-    "jotai": "https://pkg.pr.new/jotai@3293",
+    "jotai": "2.20.0",
     "jotai-tanstack-query": "^0.9.0",
     "lint-staged": "^16.4.0",
     "postcss": "^8.5.8",
@@ -160,7 +160,7 @@
     "webpack": "^5.105.4"
   },
   "peerDependencies": {
-    "jotai": ">=2.14.0",
+    "jotai": ">=2.20.0",
     "react": ">=17.0.0"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,11 +187,11 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(jest@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.5.0)(typescript@6.0.2)))
       jotai:
-        specifier: ^2.19.0
-        version: 2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
+        specifier: https://pkg.pr.new/jotai@3293
+        version: https://pkg.pr.new/jotai@3293(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
       jotai-tanstack-query:
         specifier: ^0.9.0
-        version: 0.9.2(@tanstack/query-core@5.95.2)(jotai@2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1))
+        version: 0.9.2(@tanstack/query-core@5.95.2)(jotai@https://pkg.pr.new/jotai@3293(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1))
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
@@ -4306,12 +4306,14 @@ packages:
 
   jotai-tanstack-query@0.9.2:
     resolution: {integrity: sha512-bN91r5zHTVPkYYKgo4fOQOU/ATRByq0xZOaooP/VlLxdLaJh43uGYpG4RWnDVnj3/CPLJfLSfAdTQ2L9nEft2A==}
+    version: 0.9.2
     peerDependencies:
       '@tanstack/query-core': '*'
       jotai: '>=2.0.0'
 
-  jotai@2.19.0:
-    resolution: {integrity: sha512-r2wwxEXP1F2JteDLZEOPoIpAHhV89paKsN5GWVYndPNMMP/uVZDcC+fNj0A8NjKgaPWzdyO8Vp8YcYKe0uCEqQ==}
+  jotai@https://pkg.pr.new/jotai@3293:
+    resolution: {tarball: https://pkg.pr.new/jotai@3293}
+    version: 2.19.1
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@babel/core': '>=7.0.0'
@@ -10986,12 +10988,12 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jotai-tanstack-query@0.9.2(@tanstack/query-core@5.95.2)(jotai@2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)):
+  jotai-tanstack-query@0.9.2(@tanstack/query-core@5.95.2)(jotai@https://pkg.pr.new/jotai@3293(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)):
     dependencies:
       '@tanstack/query-core': 5.95.2
-      jotai: 2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
+      jotai: https://pkg.pr.new/jotai@3293(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
 
-  jotai@2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1):
+  jotai@https://pkg.pr.new/jotai@3293(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1):
     optionalDependencies:
       '@babel/core': 7.29.0
       '@babel/template': 7.28.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,11 +187,11 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(jest@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.4))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@25.5.0)(typescript@6.0.2)))
       jotai:
-        specifier: https://pkg.pr.new/jotai@3293
-        version: https://pkg.pr.new/jotai@3293(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
+        specifier: 2.20.0
+        version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
       jotai-tanstack-query:
         specifier: ^0.9.0
-        version: 0.9.2(@tanstack/query-core@5.95.2)(jotai@https://pkg.pr.new/jotai@3293(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1))
+        version: 0.9.2(@tanstack/query-core@5.95.2)(jotai@2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1))
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
@@ -4306,14 +4306,12 @@ packages:
 
   jotai-tanstack-query@0.9.2:
     resolution: {integrity: sha512-bN91r5zHTVPkYYKgo4fOQOU/ATRByq0xZOaooP/VlLxdLaJh43uGYpG4RWnDVnj3/CPLJfLSfAdTQ2L9nEft2A==}
-    version: 0.9.2
     peerDependencies:
       '@tanstack/query-core': '*'
       jotai: '>=2.0.0'
 
-  jotai@https://pkg.pr.new/jotai@3293:
-    resolution: {tarball: https://pkg.pr.new/jotai@3293}
-    version: 2.19.1
+  jotai@2.20.0:
+    resolution: {integrity: sha512-b5GAqgmXmXzB4WPaTH26ppk9Sl7AA9WSQX7yfdM+gJ1rFROiWcVbi97gFuN/yVCojOcbcvop2sfLL+fjxW0JVg==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@babel/core': '>=7.0.0'
@@ -10988,12 +10986,12 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jotai-tanstack-query@0.9.2(@tanstack/query-core@5.95.2)(jotai@https://pkg.pr.new/jotai@3293(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)):
+  jotai-tanstack-query@0.9.2(@tanstack/query-core@5.95.2)(jotai@2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)):
     dependencies:
       '@tanstack/query-core': 5.95.2
-      jotai: https://pkg.pr.new/jotai@3293(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
+      jotai: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
 
-  jotai@https://pkg.pr.new/jotai@3293(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1):
+  jotai@2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1):
     optionalDependencies:
       '@babel/core': 7.29.0
       '@babel/template': 7.28.6

--- a/src/utils/internals/compose-with-devtools.ts
+++ b/src/utils/internals/compose-with-devtools.ts
@@ -1,8 +1,8 @@
 import { Atom, WritableAtom } from 'jotai';
 import { INTERNAL_overrideCreateStore } from 'jotai/vanilla';
 import {
-  INTERNAL_buildStoreRev2 as INTERNAL_buildStore,
-  INTERNAL_initializeStoreHooksRev2 as INTERNAL_initializeStoreHooks,
+  INTERNAL_buildStoreRev3 as INTERNAL_buildStore,
+  INTERNAL_initializeStoreHooksRev3 as INTERNAL_initializeStoreHooks,
 } from 'jotai/vanilla/internals';
 import {
   AnyAtom,
@@ -170,7 +170,7 @@ const createDevStore = (): StoreWithDevMethods => {
     undefined,
     storeHooks,
     undefined,
-    (_store, atom, get, set, ...args) => {
+    (_buildingBlocks, _store, atom, get, set, ...args) => {
       if (inRestoreAtom) {
         return set(atom, ...(args as any));
       }


### PR DESCRIPTION
### Changes
- Support `INTERNAL_buildStoreRev3` (https://github.com/pmndrs/jotai/pull/3293)
- Drops support for `INTERNAL_buildStoreRev2`


### Remaining tasks
- [x] Update docs + peer deps with new Jotai version once https://github.com/pmndrs/jotai/pull/3293/ is released
- [x] Update `package.json` with the new Jotai version instead of `pkg.pr.new`
 