### PR TITLE
chore: fix typo "seperate" → "separate" in tsup.config.ts

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,7 +19,7 @@ const baseConfig: Options = {
   // Outputs `dist/index.js` and `dist/utils.js`
   entry: {
     index: 'src/index.ts',
-    // Workaround to generate seperate chunks for DevTools so we could export a null component for production builds
+    // Workaround to generate separate chunks for DevTools so we could export a null component for production builds
     internal__devtools: 'src/DevTools/index.ts',
     utils: 'src/utils/index.ts',
   },


### PR DESCRIPTION
Comment-only fix in `tsup.config.ts`: corrects the typo "seperate" → "separate" in a build-config inline comment. No behavior change.
